### PR TITLE
Expose DiffusionImputer from maskers package

### DIFF
--- a/shap/maskers/__init__.py
+++ b/shap/maskers/__init__.py
@@ -1,5 +1,5 @@
 from ._composite import Composite
-from ._dishap import ConditionalGeneratorMasker
+from ._dishap import ConditionalGeneratorMasker, DiffusionImputer
 from ._fixed import Fixed
 from ._fixed_composite import FixedComposite
 from ._image import Image
@@ -11,6 +11,7 @@ from ._text import Text
 __all__ = [
     "Composite",
     "ConditionalGeneratorMasker",
+    "DiffusionImputer",
     "Fixed",
     "FixedComposite",
     "Image",


### PR DESCRIPTION
## Summary
- import `DiffusionImputer` in the maskers package namespace
- include `DiffusionImputer` in the public `__all__` export list

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df486e38a08332863f16ac432f4a10