### PR TITLE
Add kernel-style diffusion masker tests

### DIFF
--- a/tests/maskers/test_dishap_diffusion.py
+++ b/tests/maskers/test_dishap_diffusion.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import shap
 
 
 def _load_dishap_module():
@@ -161,6 +162,24 @@ class MockDiffusionBackbone:
         return baseline
 
 
+def build_correlated_dataset(n_samples=240, random_state=0):
+    rng = np.random.RandomState(random_state)
+    base = rng.normal(size=n_samples)
+    correlated_1 = base + 0.01 * rng.normal(size=n_samples)
+    correlated_2 = base + 0.01 * rng.normal(size=n_samples)
+    independent = rng.normal(size=n_samples)
+    X = np.column_stack([correlated_1, correlated_2, independent])
+
+    regression_weights = np.array([1.2, -0.8, 0.5])
+    regression_targets = X @ regression_weights
+
+    classification_weights = np.array([1.5, 1.5, -0.75])
+    logits = X @ classification_weights
+    probabilities = 1.0 / (1.0 + np.exp(-logits))
+
+    return X, regression_targets, probabilities
+
+
 def compute_expected_draws(x, mask, n_samples, seed_state):
     rng = np.random.RandomState(seed_state)
     expected = np.tile(x, (n_samples, 1))
@@ -232,3 +251,65 @@ def test_diffusion_imputer_rng_reproducibility():
     samples_b = imputer_b.sample(x, mask, 5)
 
     assert np.allclose(samples_a, samples_b)
+
+
+def test_diffusion_masker_kernel_shap_regression_behaviour():
+    X, _, _ = build_correlated_dataset()
+    background = X[:80]
+    samples = X[80:83]
+
+    def predict(inputs: np.ndarray, _mask: np.ndarray | None = None) -> np.ndarray:
+        return inputs @ np.array([1.2, -0.8, 0.5])
+
+    kernel_explainer = shap.KernelExplainer(predict, background, nsamples=64)
+    phi_kernel = np.asarray(kernel_explainer.shap_values(samples))
+
+    backbone = MockDiffusionBackbone()
+    generator = _dishap.DiffusionImputer(backbone, ensure_observed=True, random_state=0)
+    masker = _dishap.ConditionalGeneratorMasker(background, generator=generator, m_mc=64, random_state=0)
+
+    np.random.seed(0)
+    explainer = shap.Explainer(predict, masker, algorithm="permutation")
+    np.random.seed(0)
+    values = explainer(samples, max_evals=128, silent=True).values
+
+    assert values.shape == phi_kernel.shape
+    assert values.ndim == 2
+
+    kernel_imbalance = float(np.abs(phi_kernel[:, 0] - phi_kernel[:, 1]).mean())
+    conditional_imbalance = float(np.abs(values[:, 0] - values[:, 1]).mean())
+    assert not np.isclose(conditional_imbalance, kernel_imbalance)
+
+
+def test_diffusion_masker_supports_probability_models():
+    X, _, _ = build_correlated_dataset(random_state=1)
+    background = X[:80]
+    samples = X[80:84]
+
+    def proba_positive(inputs: np.ndarray, _mask: np.ndarray | None = None) -> np.ndarray:
+        logits = inputs @ np.array([1.5, 1.5, -0.75])
+        return 1.0 / (1.0 + np.exp(-logits))
+
+    kernel_explainer = shap.KernelExplainer(proba_positive, background, nsamples=64)
+    phi_kernel = np.asarray(kernel_explainer.shap_values(samples))
+
+    backbone = MockDiffusionBackbone()
+    generator = _dishap.DiffusionImputer(backbone, ensure_observed=True, random_state=7)
+    masker = _dishap.ConditionalGeneratorMasker(background, generator=generator, m_mc=96, random_state=11)
+
+    np.random.seed(0)
+    explainer = shap.Explainer(proba_positive, masker, algorithm="permutation")
+    np.random.seed(0)
+    values = explainer(samples, max_evals=160, silent=True).values
+
+    assert values.shape == phi_kernel.shape
+    assert values.ndim == 2
+
+    kernel_imbalance = float(np.abs(phi_kernel[:, 0] - phi_kernel[:, 1]).mean())
+    conditional_imbalance = float(np.abs(values[:, 0] - values[:, 1]).mean())
+    assert not np.isclose(conditional_imbalance, kernel_imbalance)
+
+    kernel_mean = float(phi_kernel.mean())
+    conditional_mean = float(values.mean())
+    assert np.isfinite(conditional_mean)
+    assert not np.isclose(kernel_mean, conditional_mean)


### PR DESCRIPTION
## Summary
- add a correlated tabular fixture for reuse in diffusion masker tests
- exercise the diffusion-based ConditionalGeneratorMasker with Kernel SHAP style workflows for regression and probabilistic models
- ensure outputs are well-formed and distinct from standard Kernel SHAP behaviour

## Testing
- pytest tests/maskers/test_dishap_diffusion.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e316b35bb08332b217f7665fb11153